### PR TITLE
Add a link to test the SSL certificate using SSL Labs

### DIFF
--- a/server/views/lint.jade
+++ b/server/views/lint.jade
@@ -15,7 +15,10 @@ block content
         li
           label Authoritative Domain:
           span #{authoritativeDomain}
-
+        li
+          label SSL Certificate:
+          span
+          a(href="https://www.ssllabs.com/ssltest/analyze.html?hideResults=on&d="+authoritativeDomain) test the certificate
         li
           label Authentication:
           ul


### PR DESCRIPTION
Until we fix issue #3 with real certificate checking, we could
provide a link to help IdPs diagnose potential issues with their
certificates.

The Qualys SSL Labs test tool is quite good:

  https://www.ssllabs.com/ssltest/index.html
