### PR TITLE
Fix primary detection logic when content-type is missing

### DIFF
--- a/server/lib/primary.js
+++ b/server/lib/primary.js
@@ -57,7 +57,7 @@ var fetchWellKnown = function (currentDomain, principalDomain, clientCB) {
                             ' is not a browserid primary - non-200 response code to ' +
                             WELL_KNOWN_URL);
     }
-    if (res.headers['content-type'].indexOf('application/json') !== 0) {
+    if (!res.headers['content-type'] || res.headers['content-type'].indexOf('application/json') !== 0) {
       return handleProxyIDP(currentDomain +
                             ' is not a browserid primary - non "application/json" response to ' +
                             WELL_KNOWN_URL);


### PR DESCRIPTION
If an IdP doesn't expose the content-type header, we should show
the "you must use application/json" error message instead of
crashing.
